### PR TITLE
Added two new config values

### DIFF
--- a/example-config.edn
+++ b/example-config.edn
@@ -6,12 +6,14 @@
           :outro-music-start "00:05:00"
           :end "00:05:30"}
  :music {:intro {:file "intro.mp3"
+                 :full-volume 1.0
                  :full-volume-length "00:00:30"
                  :fade-amount 0.1
                  :fade-out "00:00:15"}
          :outro {:file "outro.mp3"
                  :fade-amount 0.1
                  :fade-up "00:00:02"
+                 :full-volume 1.0
                  :full-volume-length "00:00:30"
                  :fade-out "00:00:15"}
          :bumper {:file "bumper-music.mp3"

--- a/src/podcastifier/main.clj
+++ b/src/podcastifier/main.clj
@@ -151,8 +151,8 @@
                                       (:start voices-config))]
     (segmented-linear
      2
-     1.0  (:full-volume-length intro-config)
-     1.0  (:fade-in voices-config)
+     (get intro-config :full-volume-level 1.0)  (:full-volume-length intro-config)
+     (get intro-config :full-volume-level 1.0)  (:fade-in voices-config)
      (:fade-amount intro-config) quiet-duration
      (:fade-amount intro-config) (:fade-out intro-config)
      0)))
@@ -171,17 +171,18 @@
   "Returns a sound for the outro-music part of the podcast given
   `outro-config` and `voices-config`"
   [base-dir voices-config outro-config footer]
+  (println "outtro" (get outro-config :full-volume-level 1.0))
   (let [outro-fade (segmented-linear
                     2
                     (:fade-amount outro-config) (- (:end voices-config)
                                                    (:outro-music-start voices-config))
-                    (:fade-amount outro-config) (:footer-fade-up-down voices-config)
-                    1.0                         (:footer-padding voices-config)
-                    1.0                         (:footer-fade-up-down voices-config)
-                    (:fade-amount outro-config) (duration footer)
-                    (:fade-amount outro-config) (:fade-up outro-config)
-                    1.0                         (:full-volume-length outro-config)
-                    1.0                         (:fade-out outro-config)
+                    (:fade-amount outro-config)               (:footer-fade-up-down voices-config)
+                    (get outro-config :full-volume-level 1.0) (:footer-padding voices-config)
+                    (get outro-config :full-volume-level 1.0) (:footer-fade-up-down voices-config)
+                    (:fade-amount outro-config)               (duration footer)
+                    (:fade-amount outro-config)               (:fade-up outro-config)
+                    (get outro-config :full-volume-level 1.0) (:full-volume-length outro-config)
+                    (get outro-config :full-volume-level 1.0) (:fade-out outro-config)
                     0.0) ]
     (-> outro-config
         :file


### PR DESCRIPTION
Added two new config values  to support adjusting the max volume of the intro and outtro music. Lots of the music that we are using is highly compressed and sounds much louder than the rest of the podcast. This change adds two optional config values to control the max volume of the intro and outro music from the config file:

```
    {:intro {:file "intro.mp3"
             :full-volume 1.0
             ...
             }
     :outro {:file "outro.mp3"
             :full-volume 1.0
             ...
             }
```

Both of the new config values default to 1.0, that is to the existing behavior.
