### PR TITLE
Added in pan level parameter

### DIFF
--- a/example-config.edn
+++ b/example-config.edn
@@ -1,5 +1,5 @@
 {:voices {:both "voices.wav"
-          :pan? true
+          :pan-amount 0.4
           :start "00:01:20"
           :fade-in "00:00:15"
           :intro-music-fade "00:02:25"

--- a/src/podcastifier/main.clj
+++ b/src/podcastifier/main.clj
@@ -127,14 +127,23 @@
                      'db read-decibel})}
    (-> path io/reader (java.io.PushbackReader.) )))
 
+(defn pan-value
+  "Takes a voices-config and returns the configured pan value,
+  filling the default if needed."
+  [{:keys [pan? pan-amount]}]
+  (cond
+     pan-amount pan-amount
+     pan?       0.4))
+
 (defn voices
   "Returns a Sound for the voices part of the podcast given `voices-config`."
   [base-dir voices-config footer]
-  (let [{:keys [start end pan?]
+  (let [{:keys [start end]
          fade-duration :fade-in} voices-config
+         p (pan-value voices-config)
          v (-> voices-config :both (relative-path base-dir) read-sound)
          v (trim v (subtract-time start fade-duration) end)
-         v (if pan? (pan v 0.4) v)
+         v (if p (pan v p) v)
          v-max (peak v 4000 0.99)]
     (-> v
         (gain (/ 1.0 v-max))


### PR DESCRIPTION
This is a simple configuration file change that allows you to specify the amount of left/right panning you get when you mix the two channels together.

Perviously all you could do was turn the mix/pan feature on and off with :pan?, like this:

```
  :pan? true
```

If you did turn panning it, it was always done with a pan level of 0.4. With this change you can
now specify the panning level:

```
  :pan-level 0.6
```

I've tried to keep the API backwards compatible, so that :pan true will still give you 0.4.
