### PR TITLE
process-sound: handle number of channels != 2

### DIFF
--- a/src/podcastifier/main.clj
+++ b/src/podcastifier/main.clj
@@ -156,8 +156,8 @@
         sound (if (:->stereo config) (->stereo sound) sound)
         sound (if (:pan config) (pan sound (:pan config)) sound)
         sound (fade-sound sound config)
-        sound (if (:pre-silence config) (append (silence (:pre-silence config) 2) sound) sound)
-        sound (if (:post-silence config) (append sound (silence (:post-silence config) 2)) sound)]
+        sound (if (:pre-silence config) (append (silence (:pre-silence config) (channels sound)) sound) sound)
+        sound (if (:post-silence config) (append sound (silence (:post-silence config) (channels sound))) sound)]
     sound))
 
 (defn read-sound-file


### PR DESCRIPTION
These minor changes appear to allow sounds with a single channel to be handled by process-sound.

Do they seem appropriate?